### PR TITLE
READMEを編集した

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 以下のコマンドを順に実行するとGo(echo)とMySQLの環境構築をすることができます。
 
-1. go mod init `basename $PWD`
-1. docker-compose build --no-cache
-1. docker-compose up -d
+```
+docker-compose build --no-cache
+docker-compose up -d
+```


### PR DESCRIPTION
# PRの背景

課題1のレビューで、READMEに関する以下のFBを頂いたため。

1. READMEがGitHub上でのプレビューだと崩れている。
1. git cloneをする人にとっては`go mod init`をする必要がないはず。

# 修正内容

以下にそれぞれの修正内容を記述する。

## 1) 不要なコマンドの削除

`go mod init`はgoのプロジェクトを始めるときに使うもので、リポジトリをcloneする側の人は実行する必要がないコマンド。
（自分の経験が長いLaravelで言うところの`curl -s "https://laravel.build/example-app" | bash`みたいな感じ）

## 2) 崩れているプレビュー

プレビューが崩れいている箇所がちょうど「不要なコマンドの削除」で消したコマンドだったため、完了。

close #2 